### PR TITLE
fix(#1100): when there is a selected value, show cancel button and al…

### DIFF
--- a/src/components/ComboBox/ComboBox-test.js
+++ b/src/components/ComboBox/ComboBox-test.js
@@ -11,7 +11,11 @@ import {
 import ComboBox from '../ComboBox';
 
 const findInputNode = wrapper => wrapper.find('.bx--text-input');
-const clearInput = wrapper => wrapper.instance().handleOnInputValueChange('');
+const downshiftActions = {
+  setHighlightedIndex: jest.fn(),
+};
+const clearInput = wrapper =>
+  wrapper.instance().handleOnInputValueChange('', downshiftActions);
 
 describe('ComboBox', () => {
   let mockProps;
@@ -132,10 +136,10 @@ describe('ComboBox', () => {
     it('should set `inputValue` to an empty string if a falsey-y value is given', () => {
       const wrapper = mount(<ComboBox {...mockProps} />);
 
-      wrapper.instance().handleOnInputValueChange('foo');
+      wrapper.instance().handleOnInputValueChange('foo', downshiftActions);
       expect(wrapper.state('inputValue')).toBe('foo');
 
-      wrapper.instance().handleOnInputValueChange(null);
+      wrapper.instance().handleOnInputValueChange(null, downshiftActions);
       expect(wrapper.state('inputValue')).toBe('');
     });
   });

--- a/src/components/ComboBox/ComboBox.js
+++ b/src/components/ComboBox/ComboBox.js
@@ -12,11 +12,7 @@ const defaultItemToString = item => {
   return item && item.label;
 };
 
-const defaultShouldFilterItem = ({ inputValue, item, itemToString }) =>
-  !inputValue ||
-  itemToString(item)
-    .toLowerCase()
-    .includes(inputValue.toLowerCase());
+const defaultShouldFilterItem = () => true;
 
 const getInputValue = (props, state) => {
   if (props.initialSelectedItem) {
@@ -24,6 +20,18 @@ const getInputValue = (props, state) => {
   }
 
   return state.inputValue || '';
+};
+
+const findHighlightedIndex = ({ items, itemToString }, inputValue) => {
+  if (!inputValue) {
+    return -1;
+  }
+
+  return items.findIndex(item =>
+    itemToString(item)
+      .toLowerCase()
+      .includes(inputValue.toLowerCase())
+  );
 };
 
 export default class ComboBox extends React.Component {
@@ -160,8 +168,11 @@ export default class ComboBox extends React.Component {
     event.stopPropagation();
   };
 
-  handleOnInputValueChange = inputValue => {
+  handleOnInputValueChange = (inputValue, { setHighlightedIndex }) => {
     const { onInputChange } = this.props;
+
+    setHighlightedIndex(findHighlightedIndex(this.props, inputValue));
+
     this.setState(
       () => ({
         // Default to empty string if we have a false-y `inputValue`
@@ -228,13 +239,12 @@ export default class ComboBox extends React.Component {
                   onKeyDown: this.handleOnInputKeyDown,
                 })}
               />
-              {inputValue &&
-                isOpen && (
-                  <ListBox.Selection
-                    clearSelection={clearSelection}
-                    translateWithId={translateWithId}
-                  />
-                )}
+              {inputValue && (
+                <ListBox.Selection
+                  clearSelection={clearSelection}
+                  translateWithId={translateWithId}
+                />
+              )}
               <ListBox.MenuIcon
                 isOpen={isOpen}
                 translateWithId={translateWithId}
@@ -247,7 +257,11 @@ export default class ComboBox extends React.Component {
                     <ListBox.MenuItem
                       key={itemToString(item)}
                       isActive={selectedItem === item}
-                      isHighlighted={highlightedIndex === index}
+                      isHighlighted={
+                        highlightedIndex === index ||
+                        (selectedItem && selectedItem.id === item.id) ||
+                        false
+                      }
                       {...getItemProps({ item, index })}>
                       {itemToString(item)}
                     </ListBox.MenuItem>

--- a/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/src/components/MultiSelect/FilterableMultiSelect.js
@@ -14,7 +14,6 @@ import { defaultFilterItems } from '../ComboBox/tools/filter';
 export default class FilterableMultiSelect extends React.Component {
   static propTypes = {
     ...sortingPropTypes,
-
     /**
      * Disable the control
      */


### PR DESCRIPTION
Closes IBM/carbon-components-react#

{{short description}}

#### Changelog

**New**

* {{new thing}}

Regarding #1100, I fixed point 1 and 2. 3 was already solved in #1387.

I took the Kendo combobox (https://www.telerik.com/kendo-react-ui/components/dropdowns/combobox/)
as reference to define the pending behaviors. The one thing we should fix, is to define how the selected item looks and make it different from the highlighted item. Right now, there is no selected style on the base Carbon repo.
Regarding 4, could you explain what's the point of having the input value set to the item id please? Remember the input is also used for the typeahead functionality and the input value is what's shown to the user.

Here you can see a video of what I currently have: http://nimb.ws/lrVWgq

* {{change thing}}

**Removed**

* {{removed thing}}
